### PR TITLE
Verify authenticated users can access the dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,6 @@
 class DashboardController < ApplicationController
   def show
-    @profile = current_user.profile || current_user.create_profile
+    @profile = current_user.profile
     @daily_log = current_user.daily_logs.includes(food_entries: :food).find_or_create_by(date: Date.today)
 
     calorie_calculator = CalorieCalculator.new

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -1,6 +1,15 @@
 require "test_helper"
 
 class DashboardsControllerTest < ActionDispatch::IntegrationTest
+  test "show as user" do
+    login_as varun
+
+    get root_path
+
+    assert_response :success
+    assert_select "h2", "Calories for #{Date.today.strftime("%B %d, %Y")}:"
+  end
+
   test "show as guest" do
     get root_path
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,16 @@ module ActiveSupport
     fixtures :all
 
     # Add more helper methods to be used by all tests here...
+    def login_as(user)
+      post(
+        session_path,
+        params: {
+          email_address: user.email_address,
+          password: "Passw0rd"
+        }
+      )
+    end
+
     def varun
       users(:varun)
     end


### PR DESCRIPTION
In addition to verifying that authenticated users can access the dashboard, this PR creates a `login_as` helper. Which allows users to be authenticated in integration tests.