### PR TITLE
Add rails_charts gem and implement calorie tracking charts in dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "importmap-rails"
 gem "turbo-rails"
 gem "stimulus-rails"
 gem "tailwindcss-rails"
+gem 'rails_charts', '~> 0.0.6'
 
 # OTHER
 gem "jbuilder"

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "importmap-rails"
 gem "turbo-rails"
 gem "stimulus-rails"
 gem "tailwindcss-rails"
-gem 'rails_charts', '~> 0.0.6'
+gem "rails_charts", "~> 0.0.6"
 
 # OTHER
 gem "jbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,8 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_charts (0.0.6)
+      rails
     railties (8.0.2)
       actionpack (= 8.0.2)
       activesupport (= 8.0.2)
@@ -405,6 +407,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
+  rails_charts (~> 0.0.6)
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -12,5 +12,8 @@ class DashboardController < ApplicationController
     @remaining_calories = 2000 - @total_calories
 
     @foods = []
+
+    @daily_calories_weekly = calorie_calculator.calculate_daily_calories(7)
+    @daily_calories_monthly = calorie_calculator.calculate_daily_calories(30)
   end
 end

--- a/app/models/calorie_calculator.rb
+++ b/app/models/calorie_calculator.rb
@@ -12,4 +12,22 @@ class CalorieCalculator
 
     total_calories
   end
+
+  def calculate_daily_calories(days)
+    start_date = Date.today - days
+    date_range = (start_date..Date.today).to_a
+
+    daily_calories = date_range.each_with_object({}) do |date, hash|
+      hash[date.strftime("%b %d")] = 0
+    end
+
+    logs = DailyLog.where(date: date_range)
+    logs.each do |log|
+      day_key = log.date.strftime("%b %d")
+      daily_calories[day_key] = log.food_entries.sum { |entry| entry.quantity * entry.food.calories }
+    end
+
+    daily_calories
+    # => {"Apr 11" => 0, "Apr 12" => 0, "Apr 13" => 0, "Apr 14" => 0, "Apr 15" => 0, "Apr 16" => 0, "Apr 17" => 0, "Apr 18" => 408}
+  end
 end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -25,7 +25,6 @@
                 <%= @remaining_calories %> kcal
               </span>
             </div>
-
             <div class="mt-4">
               <% percent_consumed = @total_calories > 0 ? (@total_calories.to_f / (@total_calories + @remaining_calories) * 100).round : 0 %>
               <div class="w-full bg-gray-200 rounded-full h-3">
@@ -37,6 +36,36 @@
                 <span>100%</span>
               </div>
             </div>
+           <div>
+            <h3 class="text-lg font-semibold text-gray-800 mb-4">Calories for the Past Week</h3>
+            <%= bar_chart @daily_calories_weekly,
+                class: 'box',
+                title: "Calories for the past 7 days",
+                options: {
+                  series: {
+                    barWidth: '50%'
+                  },
+                  tooltip: {
+                    valueFormatter: RailsCharts.js("(value) => value + ' kcal'")
+                  }
+                }
+              %>
+          </div>
+          <div class="mt-6">
+            <h3 class="text-lg font-semibold text-gray-800 mb-4">Calories for the Past Month</h3>
+            <%= bar_chart @daily_calories_monthly,
+                class: 'box',
+                title: "Calories for the past 30 days",
+                options: {
+                  series: {
+                    barWidth: '50%'
+                  },
+                  tooltip: {
+                    valueFormatter: RailsCharts.js("(value) => value + ' kcal'")
+                  }
+                }
+              %>
+          </div>
           </div>
         </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
This PR introduces the rails_charts gem to the project and implements calorie tracking charts in the dashboard view. The charts provide a visual representation of calorie consumption over the past week and month, enhancing the user experience by making it easier to track trends in daily calorie intake